### PR TITLE
Tell clippy to shutup about too many args to new()

### DIFF
--- a/src/controller/item_struct.rs
+++ b/src/controller/item_struct.rs
@@ -51,6 +51,7 @@ pub(crate) fn expand(mut input: ItemStruct) -> Result<TokenStream> {
         }
 
         impl #struct_name {
+            #[allow(clippy::too_many_arguments)]
             pub fn new(#(#fields),*) -> Self {
                 Self {
                     #(#field_names),*,


### PR DESCRIPTION
This method is being autogenerated based on the fields in the struct and that's not in our control and there shouldn't be a problem to have many fields in a struct so user shouldn't be bothered by this.