### PR TITLE
Fix documentation navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 This crate provides a macro named `controller` that makes it easy to decouple interactions between
 components in a `no_std` environment.
 
-[Intro](#-intro) •
-[Usage](#-usage) •
-[Details](#-details)
+[Intro](#intro) •
+[Usage](#usage) •
+[Details](#details)
 
 </div>
 


### PR DESCRIPTION
Please provide a description and rationale for this change, unless the commit title is clearly
sufficient.
