### PR TITLE
🚩 macros: Add `embassy` as the default feature

### DIFF
--- a/firmware-controller-macros/Cargo.toml
+++ b/firmware-controller-macros/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/layerx-world/firmware-controller/"
 proc-macro = true
 
 [features]
+default = ["embassy"]
 embassy = []
 tokio = []
 


### PR DESCRIPTION
This fixes standalone build of macros, which needs to happen as part of
`cargo publish`.

Please provide a description and rationale for this change, unless the commit title is clearly
sufficient.
